### PR TITLE
Make payment modular

### DIFF
--- a/src/components/BuyNowButton.astro
+++ b/src/components/BuyNowButton.astro
@@ -46,7 +46,8 @@ const buttonClass = `buy-button ${variant} ${size}`;
 ) : (
   <button 
     class={buttonClass}
-    onclick={`buyGame('${gameId}')`}
+    onclick={`buyGame('${gameId}', 'stripe')`}
+    // The "stripe" is just a placeholder, it's replaced during the checkout script.
     data-game-id={gameId}
     data-game-title={gameTitle}
     data-game-price={gamePrice}

--- a/src/components/EmailModal.astro
+++ b/src/components/EmailModal.astro
@@ -24,6 +24,13 @@
           </label>
         </div>
         <div class="form-group">
+          <label for="paymentProvider">Payment Provider:</label>
+          <select id="paymentProvider" required>
+            <option value="stripe" selected>Stripe</option>
+            // <option value="example">Example</option>
+          </select>
+        </div>
+        <div class="form-group">
           <label for="customerEmail">Email Address:</label>
           <input 
             type="email" 

--- a/src/lib/payments/index.ts
+++ b/src/lib/payments/index.ts
@@ -1,0 +1,12 @@
+import { StripeProvider } from "./stripe";
+import type { PaymentProvider } from "./types";
+
+const providers: Record<string, PaymentProvider> = {
+  stripe: StripeProvider,
+};
+
+export function getPaymentProvider(name: string): PaymentProvider {
+  const provider = providers[name];
+  if (!provider) throw new Error(`Unknown payment provider: ${name}`);
+  return provider;
+}

--- a/src/lib/payments/stripe.ts
+++ b/src/lib/payments/stripe.ts
@@ -1,0 +1,72 @@
+import Stripe from "stripe";
+import type { PaymentProvider, CheckoutSession, PurchaseDetails, WebhookResult } from "./types";
+import { getCollection } from "astro:content";
+import { siteConfig } from "../../config/site";
+import { getBaseUrl } from "../utils";
+
+const stripe = new Stripe(import.meta.env.STRIPE_SECRET_KEY!);
+
+export const StripeProvider: PaymentProvider = {
+  getName: () => "stripe",
+
+  async createCheckoutSession({ gameId, email }) {
+    // Load game data
+    const games = await getCollection("games");
+    const game = games.find((g) => g.id === gameId);
+    if (!game) throw new Error("Game not found");
+
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ["card"],
+      line_items: [
+        {
+          price_data: {
+            currency: siteConfig.site.currency.toLowerCase(),
+            product_data: {
+              name: game.data.title,
+              description: game.data.description,
+              images: game.data.thumbnail ? [`${siteConfig.site.url}${game.data.thumbnail}`] : [],
+              metadata: {
+                game_id: gameId,
+              },
+            },
+            unit_amount: Math.round(game.data.price * 100),
+          },
+          quantity: 1,
+        },
+      ],
+      mode: "payment",
+      customer_email: email,
+      success_url: `${getBaseUrl()}/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${getBaseUrl()}/`,
+      metadata: {
+        game_id: gameId,
+      },
+    });
+
+    return { id: session.id };
+  },
+
+  async handleWebhook(request: Request) {
+    const sig = request.headers.get("stripe-signature");
+    const webhookSecret = import.meta.env.STRIPE_WEBHOOK_SECRET;
+    const body = await request.text();
+
+    if (!sig || !webhookSecret) throw new Error("Missing Stripe signature or secret");
+
+    const event = stripe.webhooks.constructEvent(body, sig, webhookSecret);
+    if (event.type !== "checkout.session.completed") return null;
+
+    const session = event.data.object as Stripe.Checkout.Session;
+
+    const email = session.customer_email || session.customer_details?.email;
+    const gameId = session.metadata?.game_id;
+
+    if (!email || !gameId) throw new Error("Missing metadata in session");
+
+    return {
+      sessionId: session.id,
+      email,
+      gameId,
+    };
+  },
+};

--- a/src/lib/payments/types.ts
+++ b/src/lib/payments/types.ts
@@ -1,0 +1,21 @@
+export interface CheckoutSession {
+  id: string;
+  url?: string;
+}
+
+export interface PurchaseDetails {
+  gameId: string;
+  email: string;
+}
+
+export interface WebhookResult {
+  sessionId: string;
+  email: string;
+  gameId: string;
+}
+
+export interface PaymentProvider {
+  createCheckoutSession(details: PurchaseDetails): Promise<CheckoutSession>;
+  handleWebhook(request: Request): Promise<WebhookResult | null>;
+  getName(): string;
+}

--- a/src/pages/api/checkout.ts
+++ b/src/pages/api/checkout.ts
@@ -1,138 +1,35 @@
 import type { APIRoute } from "astro";
-import Stripe from "stripe";
-import { getCollection } from "astro:content";
-import { siteConfig } from "../../config/site";
+import { getPaymentProvider } from "../../lib/payments";
+import { getStorageAdapter } from "../../lib/storage";
 import { getBaseUrl } from "../../lib/utils";
-import { getStorageAdapter, type PurchaseData } from "../../lib/storage";
 
-// Explicitly mark this route as server-rendered
 export const prerender = false;
-
-const stripe = new Stripe(import.meta.env.STRIPE_SECRET_KEY!);
 
 export const POST: APIRoute = async ({ request }) => {
   try {
-    console.log("🛒 Checkout API called");
-    const body = await request.text();
-    console.log("📥 Received body:", body);
+    const { gameId, email, provider = "stripe" } = await request.json();
 
-    const data = body ? JSON.parse(body) : {};
-    console.log("📊 Parsed data:", data);
-
-    const { gameId, email } = data;
-    console.log("Extracted gameId:", gameId, "email:", email);
-
-    if (!gameId) {
-      console.log("No gameId found, returning error");
-      return new Response(JSON.stringify({ error: "Game ID required" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
+    if (!gameId || !email) {
+      return new Response(JSON.stringify({ error: "Missing gameId or email" }), { status: 400 });
     }
 
-    if (!email) {
-      console.log("No email found, returning error");
-      return new Response(JSON.stringify({ error: "Email required" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
-    // Load games and find the requested one
-    const games = await getCollection("games");
-    const game = games.find((g) => g.id === gameId);
-
-    if (!game) {
-      return new Response(JSON.stringify({ error: "Game not found" }), {
-        status: 404,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
-    // Check if user has already purchased this game
     const storage = await getStorageAdapter();
-    const alreadyPurchased = await storage.hasUserPurchased(email, gameId);
-
-    if (alreadyPurchased) {
-      console.log(`User ${email} already owns game ${gameId}`);
+    if (await storage.hasUserPurchased(email, gameId)) {
       return new Response(
         JSON.stringify({
-          error:
-            "You already own this game! Check your email for download links.",
-          code: "ALREADY_PURCHASED",
+          error: "You already own this game",
           recoveryUrl: `${getBaseUrl()}/recover-download`,
         }),
-        {
-          status: 409, // Conflict
-          headers: { "Content-Type": "application/json" },
-        }
+        { status: 409 }
       );
     }
 
-    // Generate download URL (placeholder for now)
-    const downloadUrl = `${getBaseUrl()}/download/${gameId}?token=placeholder`;
-    const expirationDate = new Date();
-    expirationDate.setHours(expirationDate.getHours() + 48); // 48 hour expiry
+    const paymentProvider = getPaymentProvider(provider);
+    const session = await paymentProvider.createCheckoutSession({ gameId, email });
 
-    // Create Stripe checkout session
-    const session = await stripe.checkout.sessions.create({
-      payment_method_types: ["card"],
-      line_items: [
-        {
-          price_data: {
-            currency: siteConfig.site.currency.toLowerCase(),
-            product_data: {
-              name: game.data.title,
-              description: game.data.description,
-              images: game.data.thumbnail
-                ? [`${siteConfig.site.url}${game.data.thumbnail}`]
-                : [],
-              metadata: {
-                game_id: gameId,
-                file_count: game.data.files.length.toString(),
-                total_size_gb: game.data.files
-                  .reduce((sum, f) => sum + f.size_gb, 0)
-                  .toString(),
-              },
-            },
-            unit_amount: Math.round(game.data.price * 100), // Convert to cents
-          },
-          quantity: 1,
-        },
-      ],
-      mode: "payment",
-
-      // Enable automatic tax collection if configured
-      ...(siteConfig.payments.enable_stripe_tax && {
-        automatic_tax: { enabled: true },
-        tax_id_collection: { enabled: true },
-      }),
-
-      success_url: `${getBaseUrl()}/success?session_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${getBaseUrl()}/`,
-
-      // Use the provided customer email
-      customer_email: email,
-
-      metadata: {
-        game_id: gameId,
-        store_name: siteConfig.developer.name,
-      },
-    });
-
-    console.log("✅ Stripe session created:", session.id);
-    return new Response(JSON.stringify({ sessionId: session.id }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
-  } catch (error) {
-    console.error("Stripe checkout error:", error);
-    return new Response(
-      JSON.stringify({ error: "Failed to create checkout session" }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      }
-    );
+    return new Response(JSON.stringify({ sessionId: session.id, provider }), { status: 200 });
+  } catch (err) {
+    console.error(err);
+    return new Response(JSON.stringify({ error: "Checkout error" }), { status: 500 });
   }
 };

--- a/src/pages/api/webhook.ts
+++ b/src/pages/api/webhook.ts
@@ -1,154 +1,67 @@
 import type { APIRoute } from "astro";
-import Stripe from "stripe";
+import { getPaymentProvider } from "../../lib/payments";
 import { getCollection } from "astro:content";
-import { getStorageAdapter, type PurchaseData } from "../../lib/storage";
-import { getBaseUrl } from "../../lib/utils";
+import { getStorageAdapter } from "../../lib/storage";
 import { getEmailService } from "../../lib/email";
+import { getBaseUrl } from "../../lib/utils";
 import { siteConfig } from "../../config/site";
 
-// Explicitly mark this route as server-rendered
 export const prerender = false;
 
-const stripe = new Stripe(import.meta.env.STRIPE_SECRET_KEY!);
-
-export const POST: APIRoute = async ({ request }) => {
-  console.log("🪝 Webhook endpoint called");
-
-  const sig = request.headers.get("stripe-signature");
-  const webhookSecret = import.meta.env.STRIPE_WEBHOOK_SECRET;
-
-  console.log("🔑 Webhook secret configured:", !!webhookSecret);
-  console.log("✍️ Stripe signature present:", !!sig);
-
-  if (!sig || !webhookSecret) {
-    console.error("❌ Missing stripe signature or webhook secret");
-    console.error("Webhook secret exists:", !!webhookSecret);
-    console.error("Stripe signature exists:", !!sig);
-    return new Response("Webhook signature verification failed", {
-      status: 400,
-    });
-  }
+export const POST: APIRoute = async ({ request, url }) => {
+  const providerName = url.searchParams.get("provider") || "stripe";
+  const paymentProvider = getPaymentProvider(providerName);
 
   try {
-    const body = await request.text();
+    const result = await paymentProvider.handleWebhook(request);
+    if (!result) return new Response("No action needed", { status: 200 });
 
-    // Verify the webhook signature
-    const event = stripe.webhooks.constructEvent(body, sig, webhookSecret);
+    const { sessionId, email, gameId } = result;
 
-    console.log("Webhook event received:", event.type);
+    const games = await getCollection("games");
+    const game = games.find((g) => g.id === gameId);
+    if (!game) return new Response("Game not found", { status: 404 });
 
-    // Handle successful payment
-    if (event.type === "checkout.session.completed") {
-      const session = event.data.object as Stripe.Checkout.Session;
+    const downloadToken = Buffer.from(
+      JSON.stringify({
+        sessionId,
+        email,
+        gameId,
+        issued: Date.now(),
+        expires: Date.now() + 48 * 60 * 60 * 1000,
+      })
+    ).toString("base64url");
 
-      console.log("Processing completed checkout session:", session.id);
+    const downloadUrl = `${getBaseUrl()}/download/${gameId}?token=${downloadToken}`;
 
-      // Get customer email
-      const customerEmail =
-        session.customer_email || session.customer_details?.email;
-      if (!customerEmail) {
-        console.error("No customer email found in session");
-        return new Response("No customer email", { status: 400 });
-      }
+    const expirationDate = new Date();
+    expirationDate.setHours(
+      expirationDate.getHours() + siteConfig.file_storage.download_expires_hours
+    );
 
-      // Get game ID from metadata
-      const gameId = session.metadata?.game_id;
-      if (!gameId) {
-        console.error("No game ID found in session metadata");
-        return new Response("No game ID in metadata", { status: 400 });
-      }
+    const purchaseData = {
+      sessionId,
+      gameId,
+      gameTitle: game.data.title,
+      customerEmail: email,
+      purchaseDate: new Date().toISOString(),
+      downloadUrl,
+      downloadExpires: expirationDate.toISOString(),
+      maxDownloads: 5,
+      downloadCount: 0,
+    };
 
-      // Get game details
-      const games = await getCollection("games");
-      const game = games.find((g) => g.id === gameId);
+    const storage = await getStorageAdapter();
+    await storage.storePurchase(email, purchaseData);
 
-      if (!game) {
-        console.error("Game not found:", gameId);
-        return new Response("Game not found", { status: 404 });
-      }
-
-      // Generate secure token for download verification
-      const downloadToken = generateDownloadToken(
-        session.id,
-        customerEmail,
-        gameId
-      );
-
-      // Generate download selection page URL with token
-      const downloadUrl = `${getBaseUrl()}/download/${gameId}?token=${downloadToken}`;
-
-      // Set expiration date
-      const expirationDate = new Date();
-      expirationDate.setHours(
-        expirationDate.getHours() +
-          siteConfig.file_storage.download_expires_hours
-      );
-
-      // Create purchase record
-      const purchaseData: PurchaseData = {
-        sessionId: session.id,
-        gameId: gameId,
-        gameTitle: game.data.title,
-        customerEmail: customerEmail,
-        purchaseDate: new Date().toISOString(),
-        downloadUrl: downloadUrl,
-        downloadExpires: expirationDate.toISOString(),
-        maxDownloads: 5, // Allow 5 downloads
-        downloadCount: 0,
-      };
-
-      // Store purchase data
-      const storage = await getStorageAdapter();
-      await storage.storePurchase(customerEmail, purchaseData);
-
-      console.log("Purchase data stored for:", customerEmail);
-
-      // Send email with download link
-      try {
-        console.log("📧 Attempting to send download email...");
-        const emailService = getEmailService();
-        console.log(
-          "📧 Email service configured:",
-          emailService.isConfigured()
-        );
-        console.log("📧 Sending to:", customerEmail);
-        console.log("📧 Download URL:", purchaseData.downloadUrl);
-
-        await emailService.sendDownloadEmail(purchaseData);
-        console.log("✅ Download email sent successfully to:", customerEmail);
-      } catch (emailError: any) {
-        console.error("❌ Failed to send download email:", emailError);
-        console.error("❌ Email error details:", {
-          message: emailError.message,
-          stack: emailError.stack,
-          customerEmail,
-          gameTitle: purchaseData.gameTitle,
-        });
-        // Don't fail the webhook if email fails - purchase data is still stored
-      }
+    const emailService = getEmailService();
+    if (emailService.isConfigured()) {
+      await emailService.sendDownloadEmail(purchaseData);
     }
 
     return new Response("Webhook processed", { status: 200 });
-  } catch (error) {
-    console.error("Webhook error:", error);
+  } catch (err) {
+    console.error("Webhook handler error:", err);
     return new Response("Webhook error", { status: 400 });
   }
 };
-
-// Generate a secure download token
-function generateDownloadToken(
-  sessionId: string,
-  email: string,
-  gameId: string
-): string {
-  const payload = {
-    sessionId,
-    email: email.toLowerCase(),
-    gameId,
-    issued: Date.now(),
-    expires: Date.now() + 48 * 60 * 60 * 1000, // 48 hours
-  };
-
-  // Simple base64 encoding for now - in production, use JWT or similar
-  return Buffer.from(JSON.stringify(payload)).toString("base64url");
-}

--- a/src/styles/modals.css
+++ b/src/styles/modals.css
@@ -104,8 +104,25 @@
   background: #fefefe;
 }
 
-#customerEmail::placeholder {
+#paymentProvider::placeholder {
   color: #94a3b8;
+}
+
+#paymentProvider {
+  width: 100%;
+  padding: 1rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+  box-sizing: border-box;
+  transition: all 0.2s ease;
+}
+
+#paymentProvider:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.1);
+  background: #fefefe;
 }
 
 .error-message {


### PR DESCRIPTION
This will allow more payment providers to be added.
I'll (try to) make some payment providers based on this, but I can't make a PR for them until this one is merged.

```js
export interface PaymentProvider {
  createCheckoutSession(details: PurchaseDetails): Promise<CheckoutSession>;
  handleWebhook(request: Request): Promise<WebhookResult | null>;
  getName(): string;
}
```